### PR TITLE
build(deps): bump Amazon.QLDB.Driver from 1.3.0 to 1.4.0

### DIFF
--- a/Amazon.QLDB.DMVSample.Api/Amazon.QLDB.DMVSample.Api.csproj
+++ b/Amazon.QLDB.DMVSample.Api/Amazon.QLDB.DMVSample.Api.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Amazon.Lambda.APIGatewayEvents" Version="2.5.0" />
     <PackageReference Include="Amazon.Lambda.Core" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.3.0" />
-    <PackageReference Include="Amazon.QLDB.Driver" Version="1.3.0" />
+    <PackageReference Include="Amazon.QLDB.Driver" Version="1.4.0" />
     <PackageReference Include="AWSSDK.QLDB" Version="3.7.3.113" />
     <PackageReference Include="AWSSDK.QLDBSession" Version="3.7.0.223" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Amazon.QLDB.DMVSample.LedgerSetup/Amazon.QLDB.DMVSample.LedgerSetup.csproj
+++ b/Amazon.QLDB.DMVSample.LedgerSetup/Amazon.QLDB.DMVSample.LedgerSetup.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.IonDotnet" Version="1.1.0" />
-    <PackageReference Include="Amazon.QLDB.Driver" Version="1.3.0" />
+    <PackageReference Include="Amazon.IonDotnet" Version="1.2.2" />
+    <PackageReference Include="Amazon.QLDB.Driver" Version="1.4.0" />
     <PackageReference Include="AWSSDK.QLDB" Version="3.7.3.113" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Dependabot is struggling to bump this version (#150) as its dependency on Amazon Ion also needs to be bumped.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
